### PR TITLE
Ignore bags without valid GNSS messages

### DIFF
--- a/code/marv-robotics/marv_robotics/gnss.py
+++ b/code/marv-robotics/marv_robotics/gnss.py
@@ -174,6 +174,10 @@ def gnss_plots(gps, orientation):
     gtitle = gps.title
 
     gps = yield marv.pull(gps)  # There is only one message
+    # Check whether there are any valid messages left
+    if gps is None:
+        log.error('No valid gps messages')
+        raise marv.Abort()
     gps = gps['values']
     if orientation is not None:
         otitle = orientation.title


### PR DESCRIPTION
`marv_pull` only returns valid GNSS messages. In cases where a bag only contains e.g. nan positions the already existent check (whether there are any messages at all) is not sufficient. In this case `marv.pull(gps)` returns `None`, which causes `gps = gps['values']` to crash:
```
2019-01-08 03:35:29,124 WARN marv.node.s5aor6bcap.positions.ufturrk7wi.0 skipped 1338 erroneous messages
2019-01-08 03:35:29,125 ERRO marv.cli Exception occured for dataset s5aor6bcap5vwigzexidjhjsru:
Traceback (most recent call last):
  File "/.../code/marv/marv/cli.py", line 432, in marvcli_run
    excluded_nodes, cachesize=cachesize)
  File "/.../code/marv/marv/site.py", line 384, in run
    deps=deps, cachesize=cachesize)
  File "/.../code/marv/marv_node/run.py", line 61, in run_nodes
    done, send_queue_empty = process_task(current, task)
  File "/.../code/marv/marv_node/run.py", line 315, in process_task
    return loop()
  File "/.../code/marv/marv_node/run.py", line 240, in loop
    promise = current.send(send)
  File "/.../code/marv/marv_node/driver.py", line 87, in _run
    request = gen.send(send)
  File "/.../code/marv/marv_node/node.py", line 241, in invoke
    send = yield gen.send(send)
  File "/.../code/marv-robotics/marv_robotics/gnss.py", line 177, in gnss_plots
    gps = gps['values']
```

This PR adds another check whether `marv.pull(gps)` returns `None` preventing the job from crashing due too invalid GNSS messages.