### PR TITLE
Made framerate an integer

### DIFF
--- a/code/marv-robotics/marv_robotics/cam.py
+++ b/code/marv-robotics/marv_robotics/cam.py
@@ -72,7 +72,7 @@ def ffmpeg(stream, speed, convert_32FC1_scale, convert_32FC1_offset):
                 '-f', 'rawvideo',
                 '-pixel_format', '%s' % 'gray' if mono else 'bgr24',
                 '-video_size', '%dx%d' % (rosmsg.width, rosmsg.height),
-                '-framerate', '%s' % framerate,
+                '-framerate', '%d' % round(framerate),
                 '-i', '-',
                 '-c:v', 'libvpx-vp9',
                 '-pix_fmt', 'yuv420p',


### PR DESCRIPTION
Extracting video + images was crashing in my docker container with this crash:

> [libvpx-vp9 @ 0x1099d60] Failed to initialize encoder: Invalid parameter
> [libvpx-vp9 @ 0x1099d60]   Additional information: g_timebase.num out of range [1..cfg->g_timebase.den]
> Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
> 2019-02-15 00:14:34,501 ERRO marv.cli Exception occured for dataset i3q5wgfs7mnuaallxwe43f3a7a:
> Traceback (most recent call last):
>   File "/opt/marv/local/lib/python2.7/site-packages/marv/cli.py", line 432, in marvcli_run
>     excluded_nodes, cachesize=cachesize)
>   File "/opt/marv/local/lib/python2.7/site-packages/marv/site.py", line 384, in run
>     deps=deps, cachesize=cachesize)
>   File "/opt/marv/local/lib/python2.7/site-packages/marv_node/run.py", line 61, in run_nodes
>     done, send_queue_empty = process_task(current, task)
>   File "/opt/marv/local/lib/python2.7/site-packages/marv_node/run.py", line 315, in process_task
>     return loop()
>   File "/opt/marv/local/lib/python2.7/site-packages/marv_node/run.py", line 240, in loop
>     promise = current.send(send)
>   File "/opt/marv/local/lib/python2.7/site-packages/marv_node/driver.py", line 87, in _run
>     request = gen.send(send)
>   File "/opt/marv/local/lib/python2.7/site-packages/marv_node/node.py", line 241, in invoke
>     send = yield gen.send(send)
>   File "/opt/marv/local/lib/python2.7/site-packages/marv_robotics/cam.py", line 87, in ffmpeg
>     encoder.stdin.write(img)
> IOError: [Errno 32] Broken pipe

FFMPEG settings during this crash:
> ffmpeg -f rawvideo -pixel_format bgr24 -video_size 640x480 -framerate 0.979369188112 -i - -c:v libvpx-vp9 -pix_fmt yuv420p -loglevel info -threads 8 -speed 4 -y /home/marv/site/store/i3q5wgfs7mnuaallxwe43f3a7a/.ffmpeg-1/amera_right_rgb_image_raw_throttle.webm

It seems like ffmpeg and/or vp9 don't like float framerates. They want something like 25, or 15/2 for 7.5.

This (somewhat crudely) fixes this by rounding framerate to the nearest integer. The program works as expected with this fix on my bagfile.
