### PR TITLE
Tag filter

### DIFF
--- a/code/marv/marv/db.py
+++ b/code/marv/marv/db.py
@@ -1132,7 +1132,7 @@ class Database:
                 x['value'] for x in await txn.exq(Query.from_(desc.table).select('value'))
             ]
             for desc in descs
-            if {'any', 'all', 'none'}.intersection(collection.filter_specs[desc.key].operators)
+            if {'any', 'all', 'none', 'untagged'}.intersection(collection.filter_specs[desc.key].operators)
         }
         all_known.update({
             'f_status': list(STATUS),
@@ -1225,6 +1225,12 @@ class Database:
                                                         .join(tag)
                                                         .on(dataset_tag.tag_id == tag.id)
                                                         .where(tag.value.isin(value))
+                                                        .select(dataset_tag.dataset_id)
+                                                        .distinct()))
+                elif operator == 'untagged':
+                    query = query.where(listing.id.notin(Query.from_(dataset_tag)
+                                                        .join(tag, JoinType.left_outer)
+                                                        .on(dataset_tag.tag_id == tag.id)
                                                         .select(dataset_tag.dataset_id)
                                                         .distinct()))
 

--- a/code/marv/marv/db.py
+++ b/code/marv/marv/db.py
@@ -1132,7 +1132,7 @@ class Database:
                 x['value'] for x in await txn.exq(Query.from_(desc.table).select('value'))
             ]
             for desc in descs
-            if {'any', 'all'}.intersection(collection.filter_specs[desc.key].operators)
+            if {'any', 'all', 'none'}.intersection(collection.filter_specs[desc.key].operators)
         }
         all_known.update({
             'f_status': list(STATUS),
@@ -1220,6 +1220,13 @@ class Database:
                                                         .select(dataset_tag.dataset_id)
                                                         .groupby(dataset_tag.dataset_id)
                                                         .having(fn.Count('*') == len(value))))
+                elif operator == 'none':
+                    query = query.where(listing.id.notin(Query.from_(dataset_tag)
+                                                        .join(tag)
+                                                        .on(dataset_tag.tag_id == tag.id)
+                                                        .where(tag.value.isin(value))
+                                                        .select(dataset_tag.dataset_id)
+                                                        .distinct()))
 
                 else:
                     raise UnknownOperator(operator)


### PR DESCRIPTION
Hello,

in the past i had to search for some bags that haven't been tagged before. With this i can filter for all untagged bags and for bags with do not have the specified tags.

Known issues:

* with filter "untagged" you have to specify a tag name that will not be used
* Standard configuration will not have the filter options included